### PR TITLE
Fix build on darwin

### DIFF
--- a/sqlite3vfs_normal.go
+++ b/sqlite3vfs_normal.go
@@ -1,6 +1,7 @@
 package sqlite3vfs
 
 /*
-   #cgo LDFLAGS: -Wl,--unresolved-symbols=ignore-in-object-files
+   #cgo linux LDFLAGS: -Wl,--unresolved-symbols=ignore-in-object-files
+   #cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
 */
 import "C"


### PR DESCRIPTION
We need different cgo ldflags for clang (on darwin?) to get
the same behavior of ignoring unresolved symbols from
517608a64fbf.

Fixes #6 