### PR TITLE
Remove unsupported linker flag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,12 +8,12 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        go-version: [1.17.11, 1.18.3]
+        go-version: [stable, oldstable]
         os: [ubuntu-latest]
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
       id: go

--- a/sqlite3vfs_normal.go
+++ b/sqlite3vfs_normal.go
@@ -1,7 +1,6 @@
 package sqlite3vfs
 
 /*
-   #cgo linux LDFLAGS: -Wl,--unresolved-symbols=ignore-in-object-files
    #cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
 */
 import "C"


### PR DESCRIPTION
This flag isn't supported by zig and now errors with zig 0.11.0.

The original comment said we needed this for builds with gcc, but that no longer seems to be the case. So lets try just removing it.

Fixes #11