### PR TITLE
feat(vfs): add FileControl support for PRAGMA handling

### DIFF
--- a/file.go
+++ b/file.go
@@ -63,6 +63,18 @@ type File interface {
 	DeviceCharacteristics() DeviceCharacteristic
 }
 
+// FileController is an optional interface that File implementations
+// can implement to handle file control operations like PRAGMA commands.
+type FileController interface {
+	// FileControl handles file control operations.
+	// For SQLITE_FCNTL_PRAGMA operations:
+	//   - pragmaName contains the pragma name (e.g., "litestream_time")
+	//   - pragmaValue contains the pragma value (nil for queries)
+	// Returns the result string (for queries) and any error.
+	// Return nil error with nil result for successful operations with no result.
+	FileControl(op int, pragmaName string, pragmaValue *string) (*string, error)
+}
+
 type SyncType int
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/corylanou/sqlite3vfs
+module github.com/psanford/sqlite3vfs
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/psanford/sqlite3vfs
+module github.com/corylanou/sqlite3vfs
 
 go 1.15
 

--- a/sqlite3vfs.c
+++ b/sqlite3vfs.c
@@ -147,6 +147,10 @@ int s3vfsFileControl(sqlite3_file *pFile, int op, void *pArg){
   return goVFSFileControl(pFile, op, pArg);
 }
 
+char* s3vfsSqlite3Mprintf(const char* str) {
+  return sqlite3_mprintf("%s", str);
+}
+
 const sqlite3_io_methods s3vfs_io_methods = {
   1,                               /* iVersion */
   s3vfsClose,                      /* xClose */

--- a/sqlite3vfs.c
+++ b/sqlite3vfs.c
@@ -25,6 +25,7 @@ extern int goVFSUnlock(sqlite3_file*, int eLock);
 extern int goVFSCheckReservedLock(sqlite3_file* file, int *pResOut);
 extern int goVFSSectorSize(sqlite3_file* file);
 extern int goVFSDeviceCharacteristics(sqlite3_file* file);
+extern int goVFSFileControl(sqlite3_file* file, int op, void *pArg);
 
 
 int s3vfsNew(char* name, int maxPathName) {
@@ -143,7 +144,7 @@ int s3vfsDeviceCharacteristics(sqlite3_file* file) {
 }
 
 int s3vfsFileControl(sqlite3_file *pFile, int op, void *pArg){
-  return SQLITE_NOTFOUND;
+  return goVFSFileControl(pFile, op, pArg);
 }
 
 const sqlite3_io_methods s3vfs_io_methods = {

--- a/sqlite3vfs.h
+++ b/sqlite3vfs.h
@@ -50,4 +50,6 @@ int s3vfsCurrentTimeInt64(sqlite3_vfs*, sqlite3_int64*);
 
 const extern sqlite3_io_methods s3vfs_io_methods;
 
+char* s3vfsSqlite3Mprintf(const char* str);
+
 #endif /* SQLITE3_VFS */

--- a/sqlite3vfscgo.go
+++ b/sqlite3vfscgo.go
@@ -473,7 +473,9 @@ func goVFSFileControl(cfile *C.sqlite3_file, op C.int, pArg unsafe.Pointer) C.in
 		}
 
 		if result != nil {
-			*azArg = C.CString(*result)
+			cResult := C.CString(*result)
+			*azArg = C.s3vfsSqlite3Mprintf(cResult)
+			C.free(unsafe.Pointer(cResult))
 		}
 		return C.SQLITE_OK
 	}


### PR DESCRIPTION
## Summary

- Add `FileController` interface for handling file control operations
- Implement `SQLITE_FCNTL_PRAGMA` support to enable custom PRAGMA commands
- Bridge C file control callbacks to Go implementations
- Add tests for PRAGMA set and query operations

## Context

This change addresses the need for custom PRAGMA support in Go-based SQLite VFS implementations, as discussed in [benbjohnson/litestream#849](https://github.com/benbjohnson/litestream/issues/849#issuecomment-3560194104).

When implementing time travel queries for Litestream, @asg017 suggested using custom PRAGMAs (e.g., `PRAGMA litestream_time = '[date]'`) instead of SQL functions. This approach is cleaner and more suitable for read-only environments like Datasette. However, implementing custom PRAGMAs requires FileControl support in the VFS layer, which was previously unavailable.

## Changes

1. **New `FileController` interface** (`file.go`): Optional interface that `File` implementations can implement to handle file control operations, specifically `SQLITE_FCNTL_PRAGMA`.

2. **C bridge update** (`sqlite3vfs.c`): `s3vfsFileControl` now delegates to the Go implementation instead of returning `SQLITE_NOTFOUND`.

3. **Go implementation** (`sqlite3vfscgo.go`): `goVFSFileControl` handles PRAGMA operations by:
   - Extracting pragma name and optional value from SQLite's argument array
   - Calling the `FileController` interface if implemented by the file
   - Returning results back to SQLite

4. **Tests** (`sqlite3vfs_test.go`, `tmpvfs_test.go`): Verify PRAGMA set and query operations work correctly.

## Usage

VFS implementers can now handle custom PRAGMAs by implementing the `FileController` interface:

```go
func (f *MyFile) FileControl(op int, pragmaName string, pragmaValue *string) (*string, error) {
    if pragmaName == "my_custom_pragma" {
        if pragmaValue != nil {
            // Set operation: PRAGMA my_custom_pragma = 'value'
            return nil, f.setCustomValue(*pragmaValue)
        }
        // Query operation: PRAGMA my_custom_pragma
        result := f.getCustomValue()
        return &result, nil
    }
    return nil, nil // Unknown pragma, let SQLite handle it
}
```

---

Happy to adjust the approach or implementation if you have any preferred direction - just let us know!